### PR TITLE
Add printable service sheet

### DIFF
--- a/docs/generate_service_sheet.py
+++ b/docs/generate_service_sheet.py
@@ -1,0 +1,70 @@
+from reportlab.lib.pagesizes import A4
+from reportlab.pdfgen import canvas
+from reportlab.lib.units import mm
+
+
+def draw_line(c, x1, y, x2):
+    c.line(x1, y, x2, y)
+
+
+def generate_pdf(path):
+    c = canvas.Canvas(path, pagesize=A4)
+    width, height = A4
+    margin = 20 * mm
+    y = height - margin
+
+    # Header
+    c.setFont("Helvetica-Bold", 14)
+    header = "Feuille de service – Mikael – Les Entreprises Jessica Mikael Inc."
+    c.drawString(margin, y, header)
+    y -= 20 * mm
+
+    c.setFont("Helvetica", 12)
+    line_height = 8 * mm
+    field_gap = 12 * mm
+
+    def labeled_line(label_text):
+        nonlocal y
+        c.drawString(margin, y, label_text)
+        draw_line(c, margin + 40 * mm, y - 2 * mm, width - margin)
+        y -= field_gap
+
+    labeled_line("Date :")
+    labeled_line("Heure :")
+    labeled_line("Nom du client :")
+    labeled_line("Adresse :")
+
+    c.drawString(margin, y, "Services effectués :")
+    y -= line_height
+    for _ in range(4):
+        draw_line(c, margin, y, width - margin)
+        y -= line_height
+    y -= 4 * mm
+
+    labeled_line("Prix total :")
+
+    # Payment method checkboxes
+    c.drawString(margin, y, "Mode de paiement :")
+    x = margin + 50 * mm
+    box = 4 * mm
+    c.rect(x, y - 3, box, box)
+    c.drawString(x + 6 * mm, y, "Argent")
+    x += 35 * mm
+    c.rect(x, y - 3, box, box)
+    c.drawString(x + 6 * mm, y, "Virement")
+    x += 38 * mm
+    c.rect(x, y - 3, box, box)
+    c.drawString(x + 6 * mm, y, "Crédit")
+    y -= field_gap
+
+    labeled_line("Signature de Mikael :")
+
+    c.rect(margin, y - 3, box, box)
+    c.drawString(margin + 6 * mm, y, "À facturer")
+
+    c.showPage()
+    c.save()
+
+
+if __name__ == "__main__":
+    generate_pdf("service_sheet_fr.pdf")

--- a/docs/service_sheet_fr.pdf
+++ b/docs/service_sheet_fr.pdf
@@ -1,0 +1,74 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 8 0 R /MediaBox [ 0 0 595.2756 841.8898 ] /Parent 7 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/PageMode /UseNone /Pages 7 0 R /Type /Catalog
+>>
+endobj
+6 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20250627195515+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20250627195515+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (untitled) /Trapped /False
+>>
+endobj
+7 0 obj
+<<
+/Count 1 /Kids [ 4 0 R ] /Type /Pages
+>>
+endobj
+8 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 652
+>>
+stream
+Gat$u9omaW&A@P9Qm6Pem'/^^\Lk$95e@<$&Z8s0e6N7+G*SkZT9&;SZZ3F9=B.tqVj[;9I+T'"r5nT5FoWTlG^h50&enQ3)Dr4QE)U!fS0F,87e_kb-ORc4T"G3l$qeheMB0@?%EH%o!c.p[U&@nk!S0XIp\!u11rK,AFE"STg[NkH>s*TE>ut+h3TfYA_REA>K&YU"jg)jl<lgsHC9[9>liVX&0^V/0J\jGe!stOH$p--mjuAf;%BM1fZ]FCs;.BP<NpS#R4,6Ql5G]I,7=#`J/a5\'rNLq!&ZV]<qgMD^BQQS_9]h9caq1=+Cm3*9VN&i-Y(HksJ"6n9YpBG2$+1Pd&6?[]F:bn8;"_l:1:!Ck4_M&jbK<Q@7dMBZNR\euj(s;l2NO[o38q2!7Vj+r,[*VdM`kQC-#9r&-(@m)O1,#qrLkm6V7(+c'QMW$N=fCE:^X<9/ns)_2X-5bQ?ChcfF[LJPG+?hL*S3F.;'u_\@n:A8V9lM-?S'-7/Dk4]L>lP]nTe2Mp'i,SG[$U-MJCk('^&Ol8A2p?<tN<3W5lLZu);DcX2kPSQ4Mk]4#rbqI*b)VlLiMqt)!_9Mrdl5fd'VA;VTigT"osRD&HX>&:4SqNtcIS<L.a&d#LQFgBRnr4piI>4GAp~>endstream
+endobj
+xref
+0 9
+0000000000 65535 f 
+0000000073 00000 n 
+0000000114 00000 n 
+0000000221 00000 n 
+0000000333 00000 n 
+0000000536 00000 n 
+0000000604 00000 n 
+0000000900 00000 n 
+0000000959 00000 n 
+trailer
+<<
+/ID 
+[<5804a01044f75a752f6375d92b17c376><5804a01044f75a752f6375d92b17c376>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 6 0 R
+/Root 5 0 R
+/Size 9
+>>
+startxref
+1701
+%%EOF


### PR DESCRIPTION
## Summary
- add a simple PDF service sheet in `docs/service_sheet_fr.pdf`
- provide `docs/generate_service_sheet.py` to regenerate the sheet

## Testing
- `npm test` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ef6ab81b8833290ca2fc4d891ffa1